### PR TITLE
Spread - Ignore false evaluating operands (not just null and undefined)

### DIFF
--- a/Spec.html
+++ b/Spec.html
@@ -305,7 +305,7 @@ contributors: Sebastian Markbåge
     <p>When the abstract operation CopyDataProperties is called with arguments _target_, _source_ and _excluded_, the following steps are taken:</p>
     <emu-alg>
       1. Assert: Type(_target_) is Object.
-      1. If _source_ is *undefined* or *null*, let _keys_ be a new empty List.
+      1. If ToBoolean(_source_) is *false*, let _keys_ be a new empty List.
       1. Else,
         1. Let _from_ be ToObject(_source_).
         1. Let _keys_ be ? _from_.[[OwnPropertyKeys]]().

--- a/Spread.md
+++ b/Spread.md
@@ -85,9 +85,9 @@ __Setters Are Not Executed When They're Redefined__
 let z = { set x() { throw new Error(); }, ...{ x: 1 } }; // No error
 ```
 
-__Null/Undefined Are Ignored__
+__False Evaluating Operands Are Ignored__
 ```javascript
-let emptyObject = { ...null, ...undefined }; // no runtime error
+let emptyObject = { ...false, ...null, ...undefined }; // no runtime error
 ```
 
 __Updating Deep Immutable Object__


### PR DESCRIPTION
Given this proposal is at Stage 3, it may well be too late. However, it's worth a shot.

I don't believe the existing Babel implementation is actually compliant with the current spec, but rather is compliant with the changes made in this pull request.

Rather than treating `undefined` and `null` as special cases, I believe users (and implementers) would expect to test the spread operand using [ToBoolean](https://tc39.github.io/ecma262/#sec-toboolean).

Aside from being in line with existing EcmaScript behavior, this change facilitates compact conditional property assignment  e.g.

```
const someObject = {
    ...sourceObject1,
    ...sourceObject2,
    ...mergeThirdObjectEnabled && sourceObject3
}
```

_`mergeThirdObjectEnabled` being a boolean_.

Whilst this can be achieved at present with the following:

```
const someObject = {
    ...sourceObject1,
    ...sourceObject2,
    ...mergeThirdObjectEnabled ? sourceObject3 : undefined
}
```

I don't believe users and implementers would expect the first example to be invalid.