### PR TITLE
fix typo in AssignmentRestProperty DestructuringAssignmentTarget

### DIFF
--- a/Spec.html
+++ b/Spec.html
@@ -72,7 +72,7 @@ contributors: Sebastian Markbåge
 
     <ins class="block">
       AssignmentRestProperty[Yield, Await] :
-        `...` DestructuringAssignmentTarget[Yield, Await]
+        `...` DestructuringAssignmentTarget[?Yield, ?Await]
     </ins>
 
     ObjectBindingPattern[Yield, Await] :


### PR DESCRIPTION
Working on https://github.com/tc39/ecma262/pull/1048, I believe this to be a typo that needs fixing in this proposal spec. Please correct me if I'm wrong here.